### PR TITLE
Create & update playlists on Spotify

### DIFF
--- a/app/controllers/spotify_api_controller.rb
+++ b/app/controllers/spotify_api_controller.rb
@@ -20,6 +20,11 @@ class SpotifyApiController < ApplicationController
     build_user
     @playlist = @spotify_user.playlists.find { |playlist| playlist.id == user_params[:playlist_id] }
     @tracks = build_tracklist(@playlist)
+    @my_vars = {
+      user_token: @spotify_user.credentials[:token],
+      playlist: @playlist,
+      user_id: @spotify_user.display_name
+    }
   end
 
   private

--- a/app/controllers/spotify_api_controller.rb
+++ b/app/controllers/spotify_api_controller.rb
@@ -19,7 +19,17 @@ class SpotifyApiController < ApplicationController
   def playlist_tracks
     build_user
     @playlist = @spotify_user.playlists.find { |playlist| playlist.id == user_params[:playlist_id] }
-    @tracks = []
+    @tracks = build_tracklist(@playlist)
+  end
+
+  private
+
+  def build_user
+    @spotify_user = RSpotify::User.new(user_params[:spotify_user])
+  end
+
+  def build_tracklist(playlist)
+    tracks = []
     @playlist.tracks.each do |track|
       audio_features = track.audio_features
       new_track = { name: track.name,
@@ -32,19 +42,9 @@ class SpotifyApiController < ApplicationController
                     energy: audio_features.energy }
       new_track[:camelot] = camelot_wheel(new_track[:key].to_s.to_sym, new_track[:modality])
       new_track[:key_text] = CAMELOT_TO_TEXT[new_track[:camelot].to_s.to_sym]
-      @tracks << new_track
+      tracks << new_track
     end
-    @tracks
-    # auth = { "Authorization": "Bearer #{params[:token]}" }
-    # @playlist = JSON.parse(RestClient.get("#{BASE_URL}/playlists/#{params[:playlist_id]}", auth))
-    # raise
-    # @tracks = @playlist['tracks']
-  end
-
-  private
-
-  def build_user
-    @spotify_user = RSpotify::User.new(user_params[:spotify_user])
+    tracks
   end
 
   def user_params

--- a/app/controllers/spotify_api_controller.rb
+++ b/app/controllers/spotify_api_controller.rb
@@ -39,7 +39,8 @@ class SpotifyApiController < ApplicationController
                     key: audio_features.key,
                     modality: audio_features.mode == 1 ? 'Major' : 'Minor',
                     danceability: audio_features.danceability,
-                    energy: audio_features.energy }
+                    energy: audio_features.energy,
+                    uri: track.uri }
       new_track[:camelot] = camelot_wheel(new_track[:key].to_s.to_sym, new_track[:modality])
       new_track[:key_text] = CAMELOT_TO_TEXT[new_track[:camelot].to_s.to_sym]
       tracks << new_track

--- a/app/javascript/controllers/isotope_controller.js
+++ b/app/javascript/controllers/isotope_controller.js
@@ -9,6 +9,15 @@ export default class extends Controller {
     jQueryBridget('isotope', Isotope, $);
 
     $(function () {
+
+      let myVarsJSON = $("#my_vars_json").html(),
+        myVars = JSON.parse(myVarsJSON)
+
+      const playlistId = myVars['playlist']['id']
+      const userId = myVars['user_id']
+      const userToken = myVars['user_token']
+      const baseUrl = 'https://api.spotify.com/v1'
+
       var $grid = $('.grid').isotope({
         itemSelector: '.grid-item-playlist',
         layoutMode: 'fitRows',

--- a/app/javascript/controllers/isotope_controller.js
+++ b/app/javascript/controllers/isotope_controller.js
@@ -55,36 +55,87 @@ export default class extends Controller {
       });
 
 
-      $('.playlist-button-group').on('click', 'button', function () {
-        // $grid.isotope('updateSortData', '.grid-item-playlist').isotope();
+
+      $('.update-playlist-button').on('click', function () {
+        // Get current order of tracks
         var elems = $grid.isotope('getFilteredItemElements')
-        const newTrackIndexes = elems.map(track => {
-          return track.dataset.uriValue //Find track number in the html and convert to integer.
+        const newTrackUris = elems.map(track => {
+          return track.dataset.uriValue
         })
 
-        const base_url = 'https://api.spotify.com/v1'
-
-        // Reorder the playlist tracks on spotify
+        // Replace the playlist tracks on spotify
         $.ajax({
-          url: `${base_url}/playlists/${playlist_id}/tracks`,
+          url: `${baseUrl}/playlists/${playlistId}/tracks`,
           type: "PUT",
           dataType: 'json',
           headers: {
-            'Authorization': "Bearer " + user_token,
+            'Authorization': "Bearer " + userToken,
             'Content-Type': 'application/json' },
           data: JSON.stringify({
-            'uris': newTrackIndexes,
+            'uris': newTrackUris,
           }),
           success: function () {
             alert(`Playlist Updated Successfully!`);
+            // Refresh the page.
             location.reload(true);
           },
           error: function () {
             alert(`Playlist Update Failed`);
           }
         });
-        // location.reload() to reload the page after updating the playlist.
+      });
+
+      $('.create-playlist-button').on('click', function () {
+        // Get current order of tracks
+        var elems = $grid.isotope('getFilteredItemElements')
+        const newTrackUris = elems.map(track => {
+          return track.dataset.uriValue
+        })
+
+        // Create new empty playlist
+        $.ajax({
+          url: `${baseUrl}/users/${userId}/playlists`,
+          type: "POST",
+          dataType: 'json',
+          headers: {
+            'Authorization': "Bearer " + userToken,
+            'Content-Type': 'application/json'
+          },
+          data: JSON.stringify({
+            'name': `${myVars['playlist']['name']} by BiteJockey`,
+            'description': 'Created by BiteJockey.'
+          }),
+          success: function(response) {
+            const newPlaylistId = response['id']
+            // Call function to insert tracks into new empty playlist.
+            insertTracks(newPlaylistId)
+          },
+          error: function () {
+            alert(`Playlist Creation Failed`);
+          },
+        });
+
+        function insertTracks(playlistId){
+          $.ajax({
+          url: `${baseUrl}/playlists/${playlistId}/tracks`,
+          type: "POST",
+          dataType: 'json',
+          headers: {
+            'Authorization': "Bearer " + userToken,
+            'Content-Type': 'application/json'
+          },
+          data: JSON.stringify({
+            'uris': newTrackUris,
+            'position': 0
+          }),
+          success: function () {
+            alert(`Playlist Creation Successful!`);
+            // Refresh the page.
+            location.reload(true);
+          }
+        });
+      }
       });
     });
   };
-}
+};

--- a/app/javascript/controllers/isotope_controller.js
+++ b/app/javascript/controllers/isotope_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import $ from 'jquery'
 import jQueryBridget from 'jquery-bridget'
 import Isotope from 'isotope-layout'
+import { jsonToString } from "webpack/lib/Stats";
 
 export default class extends Controller {
   connect() {
@@ -49,9 +50,31 @@ export default class extends Controller {
         // $grid.isotope('updateSortData', '.grid-item-playlist').isotope();
         var elems = $grid.isotope('getFilteredItemElements')
         const newTrackIndexes = elems.map(track => {
-          return parseInt(track.innerText.match(/(\d+)/)[0]) //Find track number in the html and convert to integer.
+          return track.dataset.uriValue //Find track number in the html and convert to integer.
         })
-        console.log(newTrackIndexes)
+
+        const base_url = 'https://api.spotify.com/v1'
+
+        // Reorder the playlist tracks on spotify
+        $.ajax({
+          url: `${base_url}/playlists/${playlist_id}/tracks`,
+          type: "PUT",
+          dataType: 'json',
+          headers: {
+            'Authorization': "Bearer " + user_token,
+            'Content-Type': 'application/json' },
+          data: JSON.stringify({
+            'uris': newTrackIndexes,
+          }),
+          success: function () {
+            alert(`Playlist Updated Successfully!`);
+            location.reload(true);
+          },
+          error: function () {
+            alert(`Playlist Update Failed`);
+          }
+        });
+        // location.reload() to reload the page after updating the playlist.
       });
     });
   };

--- a/app/views/spotify_api/playlist_tracks.html.erb
+++ b/app/views/spotify_api/playlist_tracks.html.erb
@@ -1,3 +1,7 @@
+<%= javascript_tag "user_token = '#{@spotify_user.credentials[:token]}'" %>
+<%= javascript_tag "playlist_id = '#{@playlist.id}'" %>
+<%= javascript_tag "snapshot_id = '#{@playlist.snapshot_id}'" %>
+
 <div class="container">
   <h1>Playlist Tracks</h1>
   <div class="d-flex align-items-center mb-3">
@@ -19,7 +23,7 @@
     <div class="grid">
       <% counter = 1 %>
       <% @tracks.each do |track| %>
-        <div class="grid-item-playlist shadow mb-2 p-3" data-controller="camelot">
+        <div class="grid-item-playlist shadow mb-2 p-3" data-controller="camelot" data-uri-value=<%= track[:uri]%>>
           <div class="track-features d-flex justify-content-between align-items-center">
             <div class="track-title-artist">
               <h4 class="mb-2"><%= counter %>. <%= track[:name]  %></h4>

--- a/app/views/spotify_api/playlist_tracks.html.erb
+++ b/app/views/spotify_api/playlist_tracks.html.erb
@@ -1,6 +1,3 @@
-<%= javascript_tag "user_token = '#{@spotify_user.credentials[:token]}'" %>
-<%= javascript_tag "playlist_id = '#{@playlist.id}'" %>
-
 <div class="container">
   <h1>Playlist Tracks</h1>
   <div class="d-flex align-items-center mb-3">
@@ -17,7 +14,8 @@
       <button data-sort-by="energy">Energy</button>
     </div>
     <div class="button-group playlist-button-group">
-      <button>Update Playlist</button>
+      <button class="update-playlist-button">Update Playlist</button>
+      <button class="create-playlist-button">Create New Playlist</button>
     </div>
     <div class="grid">
       <% counter = 1 %>
@@ -46,3 +44,7 @@
     </div>
   </div>
 </div>
+
+<script id="my_vars_json" type="text/json">
+    <%= raw @my_vars.to_json %>
+</script>

--- a/app/views/spotify_api/playlist_tracks.html.erb
+++ b/app/views/spotify_api/playlist_tracks.html.erb
@@ -1,6 +1,5 @@
 <%= javascript_tag "user_token = '#{@spotify_user.credentials[:token]}'" %>
 <%= javascript_tag "playlist_id = '#{@playlist.id}'" %>
-<%= javascript_tag "snapshot_id = '#{@playlist.snapshot_id}'" %>
 
 <div class="container">
   <h1>Playlist Tracks</h1>


### PR DESCRIPTION
- Added two buttons below the sorting options:

- Update: Takes the new order of the sorted tracks and overwrites the old playlist ordering. Shows a successful message and refreshes the page if this is executed successfully, which displays the new ordering of the tracks.

- Create: Actually works in two API calls, first creates an empty new playlist with the title of "#{playlist_name} by BiteJockey", we can change this to whatever later. Then it again takes the order of the newly sorted tracks, and places them in the new playlist. Also shows a successful message alert then refreshes the page when executed successfully, but this refreshes with the original playlist.

- All this code is in one big super messy javascript controller file, will definitely need to be refactored later on but it works for now!

- Also did some refactoring in the spotify_api_controller, separated some lengthy methods out.