### PR TITLE
Fix/layout fixes and so on

### DIFF
--- a/app/assets/stylesheets/pages/_playlist_tracks.scss
+++ b/app/assets/stylesheets/pages/_playlist_tracks.scss
@@ -3,6 +3,7 @@
   background-color: #121212;
   color: white;
   padding-left: 250px;
+  overflow-y: hidden;
 
   .camelot-image {
     height: 250px;
@@ -79,6 +80,10 @@
     font-family: 'Raleway';
     color: white;
   }
+}
+
+.grid-tracks {
+  width: 75%;
 }
 
 .playlist-title-description {

--- a/app/assets/stylesheets/pages/_playlist_tracks.scss
+++ b/app/assets/stylesheets/pages/_playlist_tracks.scss
@@ -45,6 +45,7 @@
 
 .playlist-tracks-header {
   margin-top: 80px;
+  padding: 16px;
   h1 {
     font-family: 'Raleway';
     font-weight: 700;

--- a/app/javascript/controllers/isotope_controller.js
+++ b/app/javascript/controllers/isotope_controller.js
@@ -20,10 +20,10 @@ export default class extends Controller {
 
       var $grid = $('.grid-tracks').isotope({
         itemSelector: '.grid-item-playlist',
-        layoutMode: 'fitRows',
-        masonry: {
-          columnWidth: 100,
-          fitWidth: true
+        layoutMode: 'vertical',
+        vertical: {
+          // align to center
+          horizontalAlignment: 0.5
         },
         transitionDuration: '0.6s',
         getSortData: {
@@ -65,6 +65,16 @@ export default class extends Controller {
         arrowIcon = $(this).find('.fa-solid');
         arrowIcon.show()
         arrowIcon.toggleClass('fa-caret-up fa-caret-down');
+        const otherButtons = $('.sort-by-button-group button')
+
+        otherButtons.each(function(index, value) {
+          const otherValue = $(value).attr('data-sort-by')
+
+          if (otherValue != sortByValue) {
+            const otherIcon = $(value).find('.fa-solid')
+            otherIcon.hide()
+          }
+        })
       });
 
 

--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -41,6 +41,6 @@ export default class extends Controller {
   #fitMapToMarkers() {
     const bounds = new mapboxgl.LngLatBounds()
     this.markersValue.forEach(marker => bounds.extend([ marker.lng, marker.lat ]))
-    this.map.fitBounds(bounds, { padding: 70, maxZoom: 15, duration: 0 })
+    this.map.fitBounds(bounds, { padding: 70, maxZoom: 15, duration: 2000 })
   }
 }

--- a/app/views/spotify_api/harmonic_sort.html.erb
+++ b/app/views/spotify_api/harmonic_sort.html.erb
@@ -21,7 +21,7 @@
   <div class="row">
     <div class="col">
       <div class="tracks-container mb-5 d-flex justify-content-center">
-        <div class="grid" data-controller='sortable' id="harmonic-cards">
+        <div class="grid" data-controller='sortable' >
           <div class="grid-heading d-flex justify-content-between p-3">
             <div class="image-and-title d-flex">
               <div class="pe-3">
@@ -38,30 +38,32 @@
               <button class="create-playlist-button btn btn-success">Create Playlist</button>
             </div>
           </div>
+          <div id="harmonic-cards">
           <% counter = 1 %>
-          <% @tracks.each do |track| %>
-            <div class="harmonic-track-card shadow mb-2 p-3" data-uri-value=<%= track[:uri]%> data-camelot-key=<%= track[:camelot]%>>
-              <div class="track-features d-flex justify-content-between align-items-center">
-                <div class="track-title-artist">
-                  <h4 class="mb-2"><% counter %> <%= track[:name]  %></h4>
-                  <p><%= track[:artist] %></p>
-                </div>
-                <div class="track-audio-features d-flex justify-content-between">
-                  <div class="mx-3 d-flex align-items-center flex-column">
-                    <span class="d-flex"><p>Key: </p><p class="key-text ms-2"><%= track[:key_text] %></p></span>
-                    <span class="d-flex"><p>Camelot Key: </p><p class="key ms-2"><%= track[:camelot] %></p></span>
-                    <span class="d-flex"><p class="key ms-2" style="color: transparent;"><%= track[:key] %></p></span>
+            <% @tracks.each do |track| %>
+              <div class="harmonic-track-card shadow mb-2 p-3" data-uri-value=<%= track[:uri]%> data-camelot-key=<%= track[:camelot]%>>
+                <div class="track-features d-flex justify-content-between align-items-center">
+                  <div class="track-title-artist">
+                    <h4 class="mb-2"><% counter %> <%= track[:name]  %></h4>
+                    <p><%= track[:artist] %></p>
                   </div>
-                  <div class="mx-3">
-                    <span class="d-flex"><p>BPM: </p><p class="bpm ms-2"><%= track[:bpm] %></p></span>
-                    <span class="d-flex"><p>Danceability: </p><p class="danceability ms-2"><%= track[:danceability] %></p></span>
-                    <span class="d-flex"><p>Energy: </p><p class="energy ms-2"><%= track[:energy] %></p></span>
+                  <div class="track-audio-features d-flex justify-content-between">
+                    <div class="mx-3 d-flex align-items-center flex-column">
+                      <span class="d-flex"><p>Key: </p><p class="key-text ms-2"><%= track[:key_text] %></p></span>
+                      <span class="d-flex"><p>Camelot Key: </p><p class="key ms-2"><%= track[:camelot] %></p></span>
+                      <span class="d-flex"><p class="key ms-2" style="color: transparent;"><%= track[:key] %></p></span>
+                    </div>
+                    <div class="mx-3">
+                      <span class="d-flex"><p>BPM: </p><p class="bpm ms-2"><%= track[:bpm] %></p></span>
+                      <span class="d-flex"><p>Danceability: </p><p class="danceability ms-2"><%= track[:danceability] %></p></span>
+                      <span class="d-flex"><p>Energy: </p><p class="energy ms-2"><%= track[:energy] %></p></span>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <% counter += 1 %>
-          <% end %>
+              <% counter += 1 %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/spotify_api/playlist_tracks.html.erb
+++ b/app/views/spotify_api/playlist_tracks.html.erb
@@ -38,7 +38,7 @@
             </div>
           </div>
         </div>
-        <div class="grid-tracks p-3 w-100">
+        <div class="grid-tracks p-3">
           <% counter = 1 %>
           <% @tracks.each do |track| %>
             <div class="grid-item-playlist border border-white mb-2 p-3" data-uri-value=<%= track[:uri]%>>

--- a/app/views/spotify_api/playlist_tracks.html.erb
+++ b/app/views/spotify_api/playlist_tracks.html.erb
@@ -30,7 +30,7 @@
           <h1 class="text-center">Sorting Options</h1>
           <div class="button-container" data-controller="isotope">
             <div class="button-group sort-by-button-group m-3">
-              <button data-sort-by="original-order" class="btn btn-outline-light">Original order</button>
+              <button data-sort-by="original-order" data-sort-direction="asc" class="btn btn-outline-light">Original order <i class="fa-solid fa-caret-up"></i></button>
               <button data-sort-by="bpm" data-sort-direction="desc" class="btn btn-outline-light">BPM <span aria-hidden="true"><i class="fa-solid fa-caret-up"></i></span></button>
               <button data-sort-by="key" data-sort-direction="desc" class="btn btn-outline-light">Song Key <i class="fa-solid fa-caret-up"></i></button>
               <button data-sort-by="danceability" data-sort-direction="desc" class="btn btn-outline-light">Danceability <i class="fa-solid fa-caret-up"></i></button>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2022_05_23_125932) do
     t.string "pronoun"
     t.text "description"
     t.string "genres"
-    t.datetime "last_checked_notifications", default: "2022-05-23 13:00:12"
+    t.datetime "last_checked_notifications", default: "2022-05-24 11:01:07"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
- Centre the track cards on the sorting page, and give them 75% width.
- Fixed the white bar on the right side of the screen.
- Fixed the arrows persisting on the sorting buttons on the first sorting page.
- Add a zoom animation to the map on loading.
- Heading on the tracks container is now no longer draggable.