### PR TITLE
Feature/user page spotify playlists

### DIFF
--- a/app/assets/stylesheets/pages/users_profile.scss
+++ b/app/assets/stylesheets/pages/users_profile.scss
@@ -21,16 +21,19 @@
     border-radius: 50%;
     object-fit: cover;
     align-self: center;
-    position: absolute;
     top: 20vh;
     left: 10vh;
+  }
+
+  .profile-avatar {
+    margin-left: 100px;
+    margin-top: 30px;
+    display: flex;
   }
 
   .banner-info {
     font-family: "Poppins", sans-serif;
     color: white;
-    margin-left: 300px;
-    margin-top: 30px;
     padding: 10px;
     background-color: rgba(27, 22, 24, 0.327);
     border-radius: 15px;
@@ -139,6 +142,7 @@
     width: 100%;
     height: 60%;
     object-fit: cover;
+    border-radius: 10px;
   }
 
   main#carousel {
@@ -169,36 +173,39 @@
     transition: all 0.25s linear;
     transform: rotateY(calc(-10deg * var(--r))) translateX(calc(-300px * var(--r)));
     z-index: calc((var(--position) - var(--abs)));
+    padding: 16px;
+    color: white;
+    border-radius: 10px;
   }
 
 
   div.item:nth-of-type(1) {
     --offset: 1;
-    background-color: #90f1ef;
+    background-color: #2222;
   }
 
 
   div.item:nth-of-type(2) {
     --offset: 2;
-    background-color: #ff70a6;
+    background-color: #2222;
   }
 
 
   div.item:nth-of-type(3) {
     --offset: 3;
-    background-color: #ff9770;
+    background-color: #2222;
   }
 
 
   div.item:nth-of-type(4) {
     --offset: 4;
-    background-color: #ffd670;
+    background-color: #2222;
   }
 
 
   div.item:nth-of-type(5) {
     --offset: 5;
-    background-color: #e9ff70;
+    background-color: #2222;
   }
 
 

--- a/app/controllers/spotify_api_controller.rb
+++ b/app/controllers/spotify_api_controller.rb
@@ -1,8 +1,6 @@
 require_relative '../../lib/camelot_keys'
 
 class SpotifyApiController < ApplicationController
-  # BASE_URL = 'https://api.spotify.com/v1'
-
   def connect
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @playlists = @user.spotify_id ? RSpotify::User.find(@user.spotify_id).playlists : []
+    @playlists = @user.spotify_id ? RSpotify::User.find(@user.spotify_id).playlists.slice(0, 5) : []
 
     @markers = [{
       lat: @user.latitude,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,8 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @playlists = RSpotify::User.find(@user.spotify_id).playlists
+    @playlists = @user.spotify_id ? RSpotify::User.find(@user.spotify_id).playlists : []
+
     @markers = [{
       lat: @user.latitude,
       lng: @user.longitude,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @playlists = RSpotify::User.find(@user.spotify_id).playlists
     @markers = [{
       lat: @user.latitude,
       lng: @user.longitude,

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -42,7 +42,7 @@
               <a class="nav-link" href="/auth/spotify"> <u>Sort My Playlists</u></a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="/auth/spotify"><u>BiteMates</u></a>
+              <a class="nav-link" href="/users"><u>BiteMates</u></a>
             </li>
           <% end %>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,56 +26,71 @@
               <input type="radio" name="position" />
               <input type="radio" name="position" />
               <main id="carousel">
-              <div class="item">
-                <img class="card-img-top" src="https://media.istockphoto.com/photos/modern-futuristic-sci-fi-concept-club-background-grunge-concrete-picture-id1063881788?k=20&m=1063881788&s=170667a&w=0&h=lR3GsH1YtiJZUH0okJmq2iLJMFkJQH5XA37SSk5sJAA=" alt="Card image cap">
-                <div class="container" id="c-item">
-                  <div class="card-body">
-                    <h5 class="card-title">Dance Hits 2000s</h5>
-                    <p class="card-text">The biggest dancefloor bangers of the 2000's</p>
-                    <a href="#" class="btn btn-info">View Playlist</a>
+                <% if @playlists.empty? %>
+                  <div class="item">
+                    <img class="card-img-top" src="https://media.istockphoto.com/photos/modern-futuristic-sci-fi-concept-club-background-grunge-concrete-picture-id1063881788?k=20&m=1063881788&s=170667a&w=0&h=lR3GsH1YtiJZUH0okJmq2iLJMFkJQH5XA37SSk5sJAA=" alt="Card image cap">
+                    <div class="container" id="c-item">
+                      <div class="card-body">
+                        <h5 class="card-title">Dance Hits 2000s</h5>
+                        <p class="card-text">The biggest dancefloor bangers of the 2000's</p>
+                        <a href="#" class="btn btn-info">View Playlist</a>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-              <div class="item">
-                <img class="card-img-top" src="https://images.unsplash.com/photo-1616855752765-2d867caa9aa7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTJ8fHRlY2hub3xlbnwwfHwwfHw%3D&auto=format&fit=crop&w=600&q=60" alt="Card image cap">
-                <div class="container" id="c-item">
-                  <div class="card-body">
-                    <h5 class="card-title">Global Groove</h5>
-                    <p class="card-text">Groovy sounds from around the world.</p>
-                    <a href="#" class="btn btn-info">View Playlist</a>
+                  <div class="item">
+                    <img class="card-img-top" src="https://images.unsplash.com/photo-1616855752765-2d867caa9aa7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTJ8fHRlY2hub3xlbnwwfHwwfHw%3D&auto=format&fit=crop&w=600&q=60" alt="Card image cap">
+                    <div class="container" id="c-item">
+                      <div class="card-body">
+                        <h5 class="card-title">Global Groove</h5>
+                        <p class="card-text">Groovy sounds from around the world.</p>
+                        <a href="#" class="btn btn-info">View Playlist</a>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-              <div class="item">
-                <img class="card-img-top" src="https://images.unsplash.com/photo-1509114397022-ed747cca3f65?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=435&q=80" alt="Card image cap">
-                <div class="container" id="c-item">
-                  <div class="card-body">
-                    <h5 class="card-title">Rave Classics</h5>
-                    <p class="card-text">Classic tunes that shaped and defined rave culture.</p>
-                    <a href="#" class="btn btn-info">View Playlist</a>
+                  <div class="item">
+                    <img class="card-img-top" src="https://images.unsplash.com/photo-1509114397022-ed747cca3f65?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=435&q=80" alt="Card image cap">
+                    <div class="container" id="c-item">
+                      <div class="card-body">
+                        <h5 class="card-title">Rave Classics</h5>
+                        <p class="card-text">Classic tunes that shaped and defined rave culture.</p>
+                        <a href="#" class="btn btn-info">View Playlist</a>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-              <div class="item">
-                <img class="card-img-top" src="https://images.unsplash.com/photo-1487260211189-670c54da558d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80" alt="Card image cap">
-                <div class="container" id="c-item">
-                  <div class="card-body">
-                    <h5 class="card-title">Poolside Disco</h5>
-                    <p class="card-text">Disco, house, funk and soul for those warm summer days.</p>
-                    <a href="#" class="btn btn-info">View Playlist</a>
+                  <div class="item">
+                    <img class="card-img-top" src="https://images.unsplash.com/photo-1487260211189-670c54da558d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80" alt="Card image cap">
+                    <div class="container" id="c-item">
+                      <div class="card-body">
+                        <h5 class="card-title">Poolside Disco</h5>
+                        <p class="card-text">Disco, house, funk and soul for those warm summer days.</p>
+                        <a href="#" class="btn btn-info">View Playlist</a>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-              <div class="item">
-                <img class="card-img-top" src="https://images.unsplash.com/photo-1619983081593-e2ba5b543168?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80" alt="Card image cap">
-                <div class="container" id="c-item">
-                  <div class="card-body">
-                    <h5 class="card-title">Warehouse Party</h5>
-                    <p class="card-text">Classic party anthems from the club to your ears!</p>
-                    <a href="#" class="btn btn-info">View Playlist</a>
+                  <div class="item">
+                    <img class="card-img-top" src="https://images.unsplash.com/photo-1619983081593-e2ba5b543168?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80" alt="Card image cap">
+                    <div class="container" id="c-item">
+                      <div class="card-body">
+                        <h5 class="card-title">Warehouse Party</h5>
+                        <p class="card-text">Classic party anthems from the club to your ears!</p>
+                        <a href="#" class="btn btn-info">View Playlist</a>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
+                <% else %>
+                  <% @playlists.each do |playlist| %>
+                    <div class="item">
+                      <img class="card-img-top" src=<%= playlist.images.first["url"] %> alt="Card image cap">
+                      <div class="container" id="c-item">
+                        <div class="card-body">
+                          <h5 class="card-title"><%= playlist.name %></h5>
+                          <p class="card-text"><%= playlist.description %></p>
+                          <a href=<%= playlist.external_urls["spotify"] %> class="btn btn-info">View Playlist</a>
+                        </div>
+                      </div>
+                    </div>
+                  <% end %>
+                <% end %>
               </main>
             </div>
           </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <div class="social_home">
   <div class="banner" style=" margin-top: 90px;">
       <div class="profile-avatar">
-        <img class="avatar-large" alt="avatar-large" src=<%= @user.image %>/>
+        <img class="avatar-large me-2" alt="avatar-large" src=<%= @user.image %>/>
 
         <div class="banner-info" id="banner-info">
           <h2><%=@user.user_name %></h2>
@@ -79,13 +79,12 @@
                   </div>
                 <% else %>
                   <% @playlists.each do |playlist| %>
-                    <div class="item">
+                    <div class="item border border-2 border-white bg-dark">
                       <img class="card-img-top" src=<%= playlist.images.first["url"] %> alt="Card image cap">
                       <div class="container" id="c-item">
                         <div class="card-body">
                           <h5 class="card-title"><%= playlist.name %></h5>
                           <p class="card-text"><%= playlist.description %></p>
-                          <a href=<%= playlist.external_urls["spotify"] %> class="btn btn-info">View Playlist</a>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
- Playlists carousel now shows actual Spotify playlists from that user, provided they have a spotify ID linked to their profile. If not then a default list will show.
- Playlists are styled to match the playlist sorting pages.
- User profile image and info are now positioned relative within a flexbox. Should prevent weird spacing issues.

![image](https://user-images.githubusercontent.com/18519818/170628931-3d8863a0-7840-480d-9357-080146099b09.png)
