### PR TITLE
Fix - Sidebar playlist links from Harmonic sorting page

### DIFF
--- a/app/controllers/spotify_api_controller.rb
+++ b/app/controllers/spotify_api_controller.rb
@@ -28,6 +28,7 @@ class SpotifyApiController < ApplicationController
 
   def harmonic_sort
     build_user
+    @user_hash = @spotify_user.to_hash
     @playlist = @spotify_user.playlists.find { |playlist| playlist.id == user_params[:playlist_id] }
     @tracks = build_tracklist(@playlist)
     @my_vars = {


### PR DESCRIPTION
The playlist links in the sidebar now work from the Harmonic sorting page. For now they link to the regular sorting page for that particular playlist.